### PR TITLE
Support moving pieces

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,5 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .
+
+

--- a/app/assets/javascripts/movePiece.js
+++ b/app/assets/javascripts/movePiece.js
@@ -1,0 +1,10 @@
+$( 'td.piece-square' ).on("click", function(e) {
+    e.preventDefault();
+    var borderChange = $(this).css('border-color', 'red');
+    
+});
+
+
+
+
+

--- a/app/assets/javascripts/movePiece.js
+++ b/app/assets/javascripts/movePiece.js
@@ -1,9 +1,3 @@
-$( 'td.piece-square' ).on("click", function(e) {
-    e.preventDefault();
-    var borderChange = $(this).css('border-color', 'red');
-    
-});
-
 
 
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -2,17 +2,20 @@ class PiecesController < ApplicationController
   before_action :authenticate_user!, only: [:show, :update]
 
   def show
-    @piece = Piece.find_by_id(params[:id])
-    @pieces = @piece.game.pieces
+    #show the board again
+    @game = Game.find(params[:id])
+    @pieces = @game.pieces
   end
 
   def update
-    @piece = Piece.find(params[:id])
-    @game = @piece.game
-    @color = @piece.color
-
-    x_coordinates = params[:x_position].to_i
-    y_coordinates = params[:y_position].to_i
+    @piece = Piece.find_by_id(params[:id])
+    
+    @piece.update_attributes(piece_params)
+    if @piece.valid?
+      redirect_to game_path
+    else
+      return :show, status: :not_acceptable
+    end
   end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -12,7 +12,7 @@ class PiecesController < ApplicationController
     
     @piece.update_attributes(piece_params)
     if @piece.valid?
-      redirect_to game_path
+      redirect_to game_path(game)
     else
       return :show, status: :not_acceptable
     end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,25 +1,18 @@
 class PiecesController < ApplicationController
-  before_action :authenticate_user!, only: [:show, :update]
-
+  
   def show
-    #show the board again
     @game = Game.find(params[:id])
     @pieces = @game.pieces
   end
 
   def update
-    @piece = Piece.find_by_id(params[:id])
+    @piece = Piece.find(params[:id])
     @game = @piece.game
-
-    # x = params[:x_position].to_i
-    # y = params[:y_position].to_i
 
     if @piece.update_attributes(piece_params)
       redirect_to game_path(@game)
     end
-    
   end
-    
 
   private
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -9,14 +9,17 @@ class PiecesController < ApplicationController
 
   def update
     @piece = Piece.find_by_id(params[:id])
-    
-    @piece.update_attributes(piece_params)
-    if @piece.valid?
-      redirect_to game_path(game)
-    else
-      return :show, status: :not_acceptable
+    @game = @piece.game
+
+    # x = params[:x_position].to_i
+    # y = params[:y_position].to_i
+
+    if @piece.update_attributes(piece_params)
+      redirect_to game_path(@game)
     end
+    
   end
+    
 
   private
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -21,14 +21,14 @@ class Game < ApplicationRecord
     self.pieces.where(color: true)
   end
 
-  def assign_pieces
-    pieces.where(color: true).each do |p|
-      p.update_attributes(player_id: white_user_id)
-    end
-    pieces.where(color: false).each do |p|
-      p.update_attributes(player_id: black_user_id)
-    end
-  end
+  # def assign_pieces
+  #   pieces.where(color: true).each do |p|
+  #     p.update_attributes(player_id: white_user_id)
+  #   end
+  #   pieces.where(color: false).each do |p|
+  #     p.update_attributes(player_id: black_user_id)
+  #   end
+  # end
 
   def fill_board
     # fill white pieces

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -13,32 +13,12 @@ class Piece < ApplicationRecord
   def move_to!(x, y)
     if unoccupied?(x,y)
       update_attributes(x_position: x, y_position: y)
-    elsif occupied_by_opposing_piece?
+    elsif occupied_by_opposing_piece?(x,y)
       capture_piece_at!(x,y)
       update_attributes(x_position: x, y_position: y)
-    elsif occupied_by_mycolor_piece?
+    elsif occupied_by_mycolor_piece?(x,y)
       return false
     end
-  end
-
-  def capture_piece_at!(x,y)
-    piece_at(x,y).update_attributes(x_position: nil, y_position: nil)
-  end
-
-  def unoccupied?(x,y)
-    !space_occupied?(x,y)
-  end
-
-  def occupied_by_mycolor_piece?(x,y)
-    space_occupied?(x,y) && (piece_at(x,y).color == self.color)
-  end
-
-  def occupied_by_opposing_piece?(x,y)
-    space_occupied?(x,y) && (piece_at(x,y).color != self.color)
-  end
-
-  def piece_at(x, y)
-    game.pieces.where(x_position: x, y_position: y).take
   end
 
   def valid_move?(x, y)
@@ -206,5 +186,25 @@ class Piece < ApplicationRecord
     else
       return nil
     end
+  end
+
+  def capture_piece_at!(x,y)
+    piece_at(x,y).update_attributes(x_position: nil, y_position: nil)
+  end
+
+  def unoccupied?(x,y)
+    !space_occupied?(x,y)
+  end
+
+  def occupied_by_mycolor_piece?(x,y)
+    space_occupied?(x,y) && (piece_at(x,y).color == self.color)
+  end
+
+  def occupied_by_opposing_piece?(x,y)
+    space_occupied?(x,y) && (piece_at(x,y).color != self.color)
+  end
+
+  def piece_at(x, y)
+    game.pieces.where(x_position: x, y_position: y).take
   end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,18 +1,10 @@
-<script>
-var borderChange = $( 'td.piece-square' ).on("click", function() {
-  $(this).css('border-color', 'red');
-  
-});
-</script>
-
-
 <h2 class="game-title">Chess Board</h2>
 
 <table class="game-board">
   <% 7.downto(0) do |row| %>
     <tr>
       <% 0.upto(7) do |col| %>
-        <td class="piece-square">
+        <td class="square">
           <% @pieces.each do |piece| %>
             <% if piece.x_position == col && piece.y_position == row %>
               <%= link_to image_tag(piece.image), game_piece_path(piece)%>
@@ -25,3 +17,5 @@ var borderChange = $( 'td.piece-square' ).on("click", function() {
     </tr>
   <% end %>
 </table>
+
+      

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,10 +1,18 @@
+<script>
+var borderChange = $( 'td.piece-square' ).on("click", function() {
+  $(this).css('border-color', 'red');
+  
+});
+</script>
+
+
 <h2 class="game-title">Chess Board</h2>
 
 <table class="game-board">
   <% 7.downto(0) do |row| %>
     <tr>
       <% 0.upto(7) do |col| %>
-        <td>
+        <td class="piece-square">
           <% @pieces.each do |piece| %>
             <% if piece.x_position == col && piece.y_position == row %>
               <%= link_to image_tag(piece.image), game_piece_path(piece)%>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -1,11 +1,23 @@
+<script>
+  $( document ).ready(function() {
+    $( 'td.piece-square' ).css( 'border-color', borderChange );
+    console.log(borderChange);
+  });
+
+</script>
+
+<h2 class="game-title">Chess Board</h2>
+
 <table class="game-board">
   <% 7.downto(0) do |row| %>
     <tr>
       <% 0.upto(7) do |col| %>
-        <td>
+        <td class="piece-square">
           <% @pieces.each do |piece| %>
             <% if piece.x_position == col && piece.y_position == row %>
-              <%= image_tag(piece.image, class: piece_class(@piece, piece)) %>
+              <%= link_to image_tag(piece.image), game_piece_path(piece)%>
+            <% elsif piece.x_position == col && piece.y_position == row %>
+              <%= link_to image_tag(piece.image), game_piece_path(piece) %>
             <% end %>
           <% end %>
         </td>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -1,18 +1,10 @@
-<script>
-  $( document ).ready(function() {
-    $( 'td.piece-square' ).css( 'border-color', borderChange );
-    console.log(borderChange);
-  });
-
-</script>
-
 <h2 class="game-title">Chess Board</h2>
 
 <table class="game-board">
   <% 7.downto(0) do |row| %>
     <tr>
       <% 0.upto(7) do |col| %>
-        <td class="piece-square">
+        <td class="square">
           <% @pieces.each do |piece| %>
             <% if piece.x_position == col && piece.y_position == row %>
               <%= link_to image_tag(piece.image), game_piece_path(piece)%>
@@ -25,3 +17,13 @@
     </tr>
   <% end %>
 </table>
+
+<script>
+$( document ).ready(function() {
+  $( 'td.square' ).on("click", function(e) {
+    e.preventDefault();
+    $( this ).css('border-color', 'red');
+    
+  });
+});
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
     member do
       patch :join
     end
-    resources :pieces, only: [:update, :create, :show]
+    resources :pieces, only: [:show, :update]
   end
 end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe PiecesController, type: :controller do
+  describe 'update action' do
+    it 'should redirect to game path when piece is moved' do
+      user1 = FactoryGirl.create(:user)
+      game = FactoryGirl.create(:game, white_user_id: user1.id )
+      piece = FactoryGirl.create(:piece, game: game, user_id: user1.id, x_position: 0, y_position: 0)
 
+      piece.update_attributes(x_position: 1, y_position: 1)
+      
+      expect(response).to redirect_to game_path(game)
+    end
+  end
 end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PiecesController, type: :controller do
       game = FactoryGirl.create(:game, white_user_id: user1.id )
       piece = FactoryGirl.create(:piece, game: game, user_id: user1.id, x_position: 0, y_position: 0)
 
-      piece.update_attributes(x_position: 1, y_position: 1)
+      put :update, game_id: game.id, id: piece.id, piece: {x_position: 1, y_position: 1}
       
       expect(response).to redirect_to game_path(game)
     end


### PR DESCRIPTION
According to the Trello task: 

Each Piece on the board is a link to a separate page that redraws a board. It accessed through a GET /pieces/:id request. The square can be highlighted on the second page.

Testing showing that when a pieces position is updated that the update triggers a redirect to the games_path(game).